### PR TITLE
Static export

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+const client = require("./sanity.js")
+
 module.exports = {
   /*
   ** Headers of the page
@@ -70,6 +72,22 @@ module.exports = {
           exclude: /(node_modules)/
         })
       }
+    }
+  },
+  generate: {
+    routes: async function() {
+      const paths = await client.fetch(`{
+        "product": *[_type == "product"].slug.current,
+        "category": *[_type == "category"].slug.current,
+        "vendor": *[_type == "vendor"].slug.current
+      }`)
+      return Object.keys(paths).reduce(
+        (acc, key) => [
+          ...acc,
+          ...paths[key].reduce((acc, curr) => [...acc, `${key}/${curr}`], [])
+        ],
+        []
+      )
     }
   }
 }

--- a/sanity.js
+++ b/sanity.js
@@ -1,6 +1,6 @@
-import sanityClient from "@sanity/client"
+const sanityClient = require("@sanity/client")
 
-export default sanityClient({
+module.exports = sanityClient({
   // Find your project ID and dataset in `sanity.json` in your studio project or on https://manage.sanity.io
   projectId: "ru2xdibx",
   dataset: "production",


### PR DESCRIPTION
This PR adds configuration for Nuxt to get (the first 100) products, vendors and categories from Sanity for routes when generating a static version of the site. 

I rewrote `sanity.js` to a CommonJS module in order to reuse the configuration, I guess we could also have added babel to the generate script, but that seemed like more hassle. 